### PR TITLE
Allow RegionLoader to work with bed files with headers.

### DIFF
--- a/src/main/java/abra/RegionLoader.java
+++ b/src/main/java/abra/RegionLoader.java
@@ -39,6 +39,10 @@ public class RegionLoader {
 			int cnt = 0;
 			
 			while (line != null) {
+				if(line.startsWith("#")) {
+					line = reader.readLine();
+					continue;
+				}
 				String[] fields = line.split("\t");
 				
 				String chromosome = fields[SEQNAME_IDX];


### PR DESCRIPTION
Currently, RegionLoader throws an ArrayOutOfBoundsException when given a bed file with a header line.

This patch tells it to skip these lines.